### PR TITLE
Bump asciidoctor-revealjs to 5.2.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -49,7 +49,7 @@ To create slides programmatically using the AsciidoctorJ API use the following c
                 .safe(SafeMode.UNSAFE)
                 .attributes(
                     AttributesBuilder.attributes()
-                        .attribute("revealjsdir", "https://cdn.jsdelivr.net/npm/reveal.js@4.3.1")
+                        .attribute("revealjsdir", "https://cdn.jsdelivr.net/npm/reveal.js@4.5.0")
                 )
                 .get()
         );
@@ -63,7 +63,7 @@ Using the CLI you can create slides with this call:
 ----
 asciidoctorj --classpath ..asciidoctor-revealjs.jar \
              -b revealjs \
-             -a revealjsdir=https://cdn.jsdelivr.net/npm/reveal.js@4.3.1 \
+             -a revealjsdir=https://cdn.jsdelivr.net/npm/reveal.js@4.5.0 \
              document.adoc
 ----
 
@@ -85,7 +85,7 @@ To create slides using the Asciidoctor Maven Plugin you can use the following pl
           </requires>
           <attributes>
             <revealjsdir>
-              https://cdn.jsdelivr.net/npm/reveal.js@4.3.1
+              https://cdn.jsdelivr.net/npm/reveal.js@4.5.0
             </revealjsdir>
           </attributes>
         </configuration>

--- a/asciidoctorj-revealjs/gradle.properties
+++ b/asciidoctorj-revealjs/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ Reveal.js
 description=AsciidoctorJ RevealJs bundles the Asciidoctor Reveal.js RubyGem (asciidoctor-reveal.js) so it can be loaded into the JVM using JRuby.
-version=5.1.0
+version=5.2.0
 gem_name=asciidoctor-revealjs

--- a/asciidoctorj-revealjs/src/test/java/org/asciidoctor/WhenBackendIsRevealJs.java
+++ b/asciidoctorj-revealjs/src/test/java/org/asciidoctor/WhenBackendIsRevealJs.java
@@ -42,7 +42,7 @@ public class WhenBackendIsRevealJs {
                 .safe(SafeMode.UNSAFE)
                 .attributes(
                     AttributesBuilder.attributes()
-                        .attribute("revealjsdir", "https://cdn.jsdelivr.net/npm/reveal.js@4.3.1")
+                        .attribute("revealjsdir", "https://cdn.jsdelivr.net/npm/reveal.js@4.5.0")
                 )
                 .get()
         );
@@ -56,7 +56,7 @@ public class WhenBackendIsRevealJs {
             .map(element -> element.attr("href"))
             .collect(toList());
 
-        assertThat(stylesheets, hasItem("https://cdn.jsdelivr.net/npm/reveal.js@4.3.1/dist/theme/black.css"));
+        assertThat(stylesheets, hasItem("https://cdn.jsdelivr.net/npm/reveal.js@4.5.0/dist/theme/black.css"));
 
         Element firstChild = doc.body().children().first();
         assertThat(firstChild.className(), containsString("reveal"));

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=5.1.0
+version=5.2.0
 sourceCompatibility=1.8
 targetCompatibility=1.8

--- a/itest/src/test/java/org/asciidoctor/WhenBackendIsRevealJs.java
+++ b/itest/src/test/java/org/asciidoctor/WhenBackendIsRevealJs.java
@@ -45,7 +45,7 @@ public class WhenBackendIsRevealJs {
                 .safe(SafeMode.UNSAFE)
                 .attributes(
                     AttributesBuilder.attributes()
-                    .attribute("revealjsdir", "https://cdn.jsdelivr.net/npm/reveal.js@4.3.1")
+                    .attribute("revealjsdir", "https://cdn.jsdelivr.net/npm/reveal.js@4.5.0")
                 )
                 .get()
         );
@@ -60,9 +60,9 @@ public class WhenBackendIsRevealJs {
             .collect(toList());
         assertThat(stylesheets,
             hasItems(
-                 //   "https://cdn.jsdelivr.net/npm/reveal.js@4.3.1/dist/reset.css",
-                    "https://cdn.jsdelivr.net/npm/reveal.js@4.3.1/dist/reveal.css",
-                    "https://cdn.jsdelivr.net/npm/reveal.js@4.3.1/dist/theme/black.css"));
+                 //   "https://cdn.jsdelivr.net/npm/reveal.js@4.5.0dist/reset.css",
+                    "https://cdn.jsdelivr.net/npm/reveal.js@4.5.0/dist/reveal.css",
+                    "https://cdn.jsdelivr.net/npm/reveal.js@4.5.0/dist/theme/black.css"));
 
         Element diagramSlide = doc.selectFirst("#diagram");
         assertThat(diagramSlide, notNullValue());


### PR DESCRIPTION
## Kind of change

[ ] Bug fix
[x] New non-breaking feature
[ ] New breaking feature
[x] Documentation update
[ ] Build improvement

## Description

What is the goal of this pull request?

Bump to latest asciidoctor-revealj version

How does it achieve that?

update dependencies + fix test assumptions

Are there any alternative ways to implement this?

no

Are there any implications of this pull request? Anything a user must know?

It's been documented


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc